### PR TITLE
Fixed 'Invalid argument supplied for foreach' exception on MiscScriptArraySerialized

### DIFF
--- a/Model/Config/Backend/Serialized/MiscScriptArraySerialized.php
+++ b/Model/Config/Backend/Serialized/MiscScriptArraySerialized.php
@@ -18,9 +18,11 @@ class MiscScriptArraySerialized extends ArraySerialized
     {
         parent::afterLoad();
         $values = $this->getValue();
-        foreach ($values as &$value) {
-            if (!array_key_exists('is_enabled', $value)) {
-                $value['is_enabled'] = '';
+        if(is_array($values)){
+            foreach ($values as &$value) {
+                if (!array_key_exists('is_enabled', $value)) {
+                    $value['is_enabled'] = '';
+                }
             }
         }
 

--- a/Model/Config/Backend/Serialized/MiscScriptArraySerialized.php
+++ b/Model/Config/Backend/Serialized/MiscScriptArraySerialized.php
@@ -18,7 +18,7 @@ class MiscScriptArraySerialized extends ArraySerialized
     {
         parent::afterLoad();
         $values = $this->getValue();
-        if(is_array($values)){
+        if (is_array($values)) {
             foreach ($values as &$value) {
                 if (!array_key_exists('is_enabled', $value)) {
                     $value['is_enabled'] = '';


### PR DESCRIPTION
After installation using composer, I got this exception on System > Configuration > Magepal > Checkout:
Exception #0 (Exception): Warning: Invalid argument supplied for foreach() in {Magento-Root-Dir}/vendor/magepal/magento2-checkout-success-misc-script/Model/Config/Backend/Serialized/MiscScriptArraySerialized.php on line 23